### PR TITLE
chore: Update copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2024 Jen-Chieh Shen
+Copyright (c) 2021-2025 Jen-Chieh Shen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the copyright year in the MIT License from 2024 to 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->